### PR TITLE
Update IDLE2HTML.py

### DIFF
--- a/idlexlib/extensions/IDLE2HTML.py
+++ b/idlexlib/extensions/IDLE2HTML.py
@@ -85,7 +85,7 @@ else:
         import tkinter as Tkinter
         import tkinter.filedialog as tkFileDialog
 
-import cgi
+import html
 
 class IDLE2HTML(object):
     menudefs=[('options',[('Export to HTML', '<<idle2html>>')])]
@@ -142,7 +142,7 @@ class IDLE2HTML(object):
                 if content.upper() == 'ERROR':
                     inside_error=1
             if tagname=='text':
-                out.append(cgi.escape(content))
+                out.append(html.escape(content))
             if tagname=='tagoff' and not (content.upper() in ('SYNC','TODO','SEL')):
                 if content.upper() == 'ERROR':
                     inside_error=0


### PR DESCRIPTION
"Export to HTML" creates an empty HTML file due to:
AttributeError: module 'cgi' has no attribute 'escape'
cgi.escape has been deprecated since Python 3.2 and has been removed in Python 3.8 (https://docs.python.org/3.7/library/cgi.html#cgi.escape)