### PR TITLE
Replace deprecated formatargspec with signature.  Need for Python 3.11+

### DIFF
--- a/idlexlib/idlefork/idlelib/CallTips.py
+++ b/idlexlib/idlefork/idlelib/CallTips.py
@@ -145,7 +145,7 @@ def get_argspec(ob):
     else:
         fob = ob
     if isinstance(fob, (types.FunctionType, types.MethodType)):
-        argspec = inspect.formatargspec(*inspect.getfullargspec(fob))
+        argspec = str(inspect.signature(fob))
         if (isinstance(ob, (type, types.MethodType)) or
                 isinstance(ob_call, types.MethodType)):
             argspec = _first_param.sub("", argspec)


### PR DESCRIPTION
This update allows the calltip to be populated.

Otherwise you'll get error: AttributeError: module 'inspect' has no attribute 'formatargspec.'
Deprecated since Python 3.5.  Removed in Python 3.11.
